### PR TITLE
Initialize useState with lazy initial state

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function getYYYYMMDD(): string {
 }
 
 export default function App() {
-  const [doc, ] = useState(yorkie.createDocument('examples', `todo-mvc-${getYYYYMMDD()}`));
+  const [doc, ] = useState(() => yorkie.createDocument('examples', `todo-mvc-${getYYYYMMDD()}`));
   const [todos, setTodos] = useState([]);
 
   const actions = {


### PR DESCRIPTION
In every time rerendering react component, the yorkie document is created but disregared. So, I initialize lazily useState state to create yorkie document only once in mount. :)

See: https://ko.reactjs.org/docs/hooks-reference.html#lazy-initial-state