### PR TITLE
Add options to scripts for supporting node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "yorkie-js-sdk": "^0.2.5"
   },
   "scripts": {
-    "start": "react-app-rewired start",
+    "start": "react-app-rewired --openssl-legacy-provider start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
**What this PR does / why we need it:**
As Node 17+ use OpenSSL 3, I added command-line option `--openssl-legacy-provider`.
  

**Which issue(s) this PR fixes:**
This PR will resolve issue #8.
  

**Additional documentation:**
https://nodejs.org/en/blog/release/v17.0.0/#openssl-3-0


(there's no contributing guide and/or pr template yet, right?  I referred to the PR template of yorkie.)