### PR TITLE
Use yorkie-js-sdk ^0.2.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "react": "^16.13.1",
         "react-dom": "^16.13.1",
         "todomvc-app-css": "^2.3.0",
-        "yorkie-js-sdk": "^0.2.5"
+        "yorkie-js-sdk": "^0.2.11"
       },
       "devDependencies": {
         "@types/classnames": "^2.2.10",
@@ -21755,9 +21755,9 @@
       }
     },
     "node_modules/yorkie-js-sdk": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.2.5.tgz",
-      "integrity": "sha512-SGO4yZvr/Lp0OC+Xp9aExA8l5t1jL5McFuI8Hd+YhZYe0g7HQivP+QE/Pvas0B57Qf/f7pa9D46qXKez66VYlw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.2.11.tgz",
+      "integrity": "sha512-DWdjq06vv+LxEhRzuOLNSQE8VPzgOIm0wk/IQnag9OIZbl8zWa3VMEoxb4M35mSUjRtYKfdy+OQyjVCl1ZjF+w==",
       "dependencies": {
         "@types/google-protobuf": "^3.15.5",
         "@types/long": "^4.0.1",
@@ -39944,9 +39944,9 @@
       }
     },
     "yorkie-js-sdk": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.2.5.tgz",
-      "integrity": "sha512-SGO4yZvr/Lp0OC+Xp9aExA8l5t1jL5McFuI8Hd+YhZYe0g7HQivP+QE/Pvas0B57Qf/f7pa9D46qXKez66VYlw==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.2.11.tgz",
+      "integrity": "sha512-DWdjq06vv+LxEhRzuOLNSQE8VPzgOIm0wk/IQnag9OIZbl8zWa3VMEoxb4M35mSUjRtYKfdy+OQyjVCl1ZjF+w==",
       "requires": {
         "@types/google-protobuf": "^3.15.5",
         "@types/long": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "todomvc-app-css": "^2.3.0",
-    "yorkie-js-sdk": "^0.2.5"
+    "yorkie-js-sdk": "^0.2.11"
   },
   "scripts": {
     "start": "react-app-rewired --openssl-legacy-provider start",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,15 +24,15 @@ function getYYYYMMDD(): string {
 }
 
 export default function App() {
-  const [doc, ] = useState(() => yorkie.createDocument(`todomvc$${getYYYYMMDD()}`));
+  const [doc, ] = useState(() => new yorkie.Document(`todomvc$${getYYYYMMDD()}`));
   const [todos, setTodos] = useState([]);
 
   const actions = {
     addTodo: (text: string) => {
       doc.update((root) => {
-        root.todos.push({
+        root['todos'].push({
           id:
-          root.todos.reduce((maxId, todo) => 
+          root['todos'].reduce((maxId, todo) => 
             Math.max(todo.id, maxId), -1
           ) + 1,
           completed: false,
@@ -43,21 +43,21 @@ export default function App() {
     deleteTodo: (id: number) => {
       doc.update((root) => {
         let target;
-        for (const todo of root.todos) {
+        for (const todo of root['todos']) {
           if (todo.id === id) {
             target = todo;
             break;
           }
         }
         if (target) {
-          root.todos.deleteByID(target.getID());
+          root['todos'].deleteByID(target.getID());
         }
       });
     },
     editTodo: (id: number, text: string) => {
       doc.update((root) => {
         let target;
-        for (const todo of root.todos) {
+        for (const todo of root['todos']) {
           if (todo.id === id) {
             target = todo;
             break;
@@ -71,7 +71,7 @@ export default function App() {
     completeTodo: (id: number) => {
       doc.update((root) => {
         let target;
-        for (const todo of root.todos) {
+        for (const todo of root['todos']) {
           if (todo.id === id) {
             target = todo;
             break;
@@ -84,19 +84,19 @@ export default function App() {
     },
     clearCompleted: () => {
       doc.update((root) => {
-        for (const todo of root.todos) {
+        for (const todo of root['todos']) {
           if (todo.completed) {
-            root.todos.deleteByID(todo.getID());
+            root['todos'].deleteByID(todo.getID());
           }
         }
-      });
+      }, "");
     }
   };
 
   useEffect(() => {
     async function attachDoc() {
       // 01. create client with RPCAddr(envoy) then activate it.
-      const client = yorkie.createClient(`${process.env.REACT_APP_YORKIE_RPC_ADDR}`);
+      const client = new yorkie.Client(`${process.env.REACT_APP_YORKIE_RPC_ADDR}`);
       await client.activate();
 
       // 02. attach the document into the client.
@@ -112,11 +112,11 @@ export default function App() {
 
       // 04. subscribe change event from local and remote.
       doc.subscribe((event) => {
-        setTodos(doc.getRoot().todos);
+        setTodos(doc.getRoot()['todos']);
       });
 
       // 05. set todos  the attached document.
-      setTodos(doc.getRoot().todos);
+      setTodos(doc.getRoot()['todos']);
     }
     attachDoc();
   }, [doc]);


### PR DESCRIPTION
What this PR does / why we need it:
Use yorkie-js-sdk ^0.2.11. 
at the moment, if users use npm then yorkie-js-sdk 0.2.5 gets installed.
however, if users use yarn rather than npm, they get yorke-js-sdk 0.2.11 instead.
I modified a little bit so that yorkie-js-sdk ^0.2.11 would be used whether users use npm or yarn.  

Which issue(s) this PR fixes:
This PR will resolve issue #7.
